### PR TITLE
(PC-42171)[API] feat: add similar artists proxy endpoint

### DIFF
--- a/src/pcproxy/connectors/recommendation.py
+++ b/src/pcproxy/connectors/recommendation.py
@@ -51,6 +51,10 @@ class RecommendationBackend:
         params["userId"] = user_id
         return await self._request("get", path, params=params)
 
+    async def get_similar_artists(self, artist_id: str) -> dict:
+        path = f"/similar_artists/{artist_id}"
+        return await self._request("get", path, params={})
+
     async def get_playlist(self, user_id: int, params: dict, body: dict) -> dict:
         path = f"/playlist_recommendation/{user_id}"
         return await self._request("post", path, params=params, body=body)

--- a/src/pcproxy/routes/artists.py
+++ b/src/pcproxy/routes/artists.py
@@ -1,0 +1,45 @@
+import asyncio
+import uuid
+
+import fastapi
+
+from pcproxy.connectors.recommendation import RecommendationBackend
+from pcproxy.connectors.recommendation import RecommendationException
+from pcproxy.main import app
+from pcproxy.serializers import artists as serializers
+from pcproxy.serializers.error import SimpleError
+
+
+@app.get("/native/v1/artists/{artist_id}/similar")
+async def similar_artists(
+    artist_id: str,
+    response: fastapi.Response,
+) -> serializers.SimilarArtistsResponse | SimpleError:
+    """Proxy pass-through to the Data Science recommendation API.
+
+    Returns the raw DS response:
+        {"similar_artists": [{"artist_id_match": "<uuid>", "rank": <int>}], "params": {...}}
+
+    This endpoint does NOT enrich results with artist metadata (name, image) and does NOT
+    filter out blacklisted artists or artists without eligible offers. That enrichment
+    is performed by pass-culture-main's homonymous route when called directly.
+
+    On DS API failure: 502 (RECOMMENDATION_API_ERROR) or 504 (RECOMMENDATION_API_TIMEOUT).
+    On invalid artist_id (non-UUID): 400.
+    """
+    try:
+        uuid.UUID(artist_id)
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST, detail="Invalid artist_id"
+        ) from exc
+
+    try:
+        result = await RecommendationBackend().get_similar_artists(artist_id=artist_id)
+    except asyncio.TimeoutError:
+        response.status_code = fastapi.status.HTTP_504_GATEWAY_TIMEOUT
+        return SimpleError(code="RECOMMENDATION_API_TIMEOUT")
+    except RecommendationException:
+        response.status_code = fastapi.status.HTTP_502_BAD_GATEWAY
+        return SimpleError(code="RECOMMENDATION_API_ERROR")
+    return serializers.SimilarArtistsResponse(**result)

--- a/src/pcproxy/serializers/artists.py
+++ b/src/pcproxy/serializers/artists.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic.alias_generators import to_snake
+
+
+class SimilarArtistMatch(BaseModel):
+    artistIdMatch: str
+    rank: int
+
+    class Config:
+        alias_generator = to_snake
+        populate_by_name = True
+        extra = "forbid"
+
+
+class SimilarArtistsApiParams(BaseModel):
+    artistId: str | None = None
+    callId: str | None = None
+
+    class Config:
+        alias_generator = to_snake
+        populate_by_name = True
+        extra = "forbid"
+
+
+class SimilarArtistsResponse(BaseModel):
+    similarArtists: list[SimilarArtistMatch] = Field(default_factory=list)
+    params: SimilarArtistsApiParams
+
+    class Config:
+        alias_generator = to_snake
+        populate_by_name = True
+        extra = "forbid"

--- a/src/pcproxy/utils/routes.py
+++ b/src/pcproxy/utils/routes.py
@@ -1,2 +1,3 @@
 def install_routes() -> None:
+    from pcproxy.routes import artists  # pylint: disable=unused-import
     from pcproxy.routes import recommendation  # pylint: disable=unused-import

--- a/tests/routes/test_artists.py
+++ b/tests/routes/test_artists.py
@@ -1,0 +1,103 @@
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from pcproxy.connectors.recommendation import RecommendationException
+from pcproxy.main import app
+
+
+client = TestClient(app)
+
+ARTIST_ID = "26b287fe-057c-42c6-bae7-40382f2ed5bf"
+
+
+class SimilarArtistsTest:
+    route = f"/native/v1/artists/{ARTIST_ID}/similar"
+
+    def test_minimal(self):
+        class BackendMock:
+            get_similar_artists = AsyncMock(
+                return_value={
+                    "similarArtists": [],
+                    "params": {
+                        "artistId": ARTIST_ID,
+                        "callId": "dc78c12c-ada1-4fc1-8cdb-2a7d40afa99f",
+                    },
+                },
+            )
+
+        with patch("pcproxy.routes.artists.RecommendationBackend", BackendMock):
+            response = client.get(self.route)
+            assert response.status_code == 200
+            BackendMock.get_similar_artists.assert_called_once_with(artist_id=ARTIST_ID)
+
+        assert response.json() == {
+            "similar_artists": [],
+            "params": {
+                "artist_id": ARTIST_ID,
+                "call_id": "dc78c12c-ada1-4fc1-8cdb-2a7d40afa99f",
+            },
+        }
+
+    def test_full(self):
+        class BackendMock:
+            get_similar_artists = AsyncMock(
+                return_value={
+                    "similarArtists": [
+                        {"artistIdMatch": "a5712e68-cb1f-4f3b-82b5-ed36379f1b2d", "rank": 1},
+                        {"artistIdMatch": "a09bd848-c9ec-4648-8be2-1dcf03c16715", "rank": 2},
+                    ],
+                    "params": {
+                        "artistId": ARTIST_ID,
+                        "callId": "dc78c12c-ada1-4fc1-8cdb-2a7d40afa99f",
+                    },
+                },
+            )
+
+        with patch("pcproxy.routes.artists.RecommendationBackend", BackendMock):
+            response = client.get(self.route)
+            assert response.status_code == 200
+            BackendMock.get_similar_artists.assert_called_once_with(artist_id=ARTIST_ID)
+
+        assert response.json() == {
+            "similar_artists": [
+                {"artist_id_match": "a5712e68-cb1f-4f3b-82b5-ed36379f1b2d", "rank": 1},
+                {"artist_id_match": "a09bd848-c9ec-4648-8be2-1dcf03c16715", "rank": 2},
+            ],
+            "params": {
+                "artist_id": ARTIST_ID,
+                "call_id": "dc78c12c-ada1-4fc1-8cdb-2a7d40afa99f",
+            },
+        }
+
+    def test_invalid_artist_id(self):
+        class BackendMock:
+            get_similar_artists = AsyncMock()
+
+        with patch("pcproxy.routes.artists.RecommendationBackend", BackendMock):
+            response = client.get("/native/v1/artists/not-a-uuid/similar")
+            BackendMock.get_similar_artists.assert_not_called()
+
+        assert response.status_code == 400
+
+    def test_timeout(self):
+        class BackendMock:
+            get_similar_artists = AsyncMock(side_effect=asyncio.TimeoutError)
+
+        with patch("pcproxy.routes.artists.RecommendationBackend", BackendMock):
+            response = client.get(self.route)
+            assert response.status_code == 504
+
+        assert response.json() == {"code": "RECOMMENDATION_API_TIMEOUT"}
+
+    def test_backend_unavailable(self):
+        class BackendMock:
+            get_similar_artists = AsyncMock(side_effect=RecommendationException)
+
+        with patch("pcproxy.routes.artists.RecommendationBackend", BackendMock):
+            response = client.get(self.route)
+            assert response.status_code == 502
+
+        assert response.json() == {"code": "RECOMMENDATION_API_ERROR"}


### PR DESCRIPTION
Ticket [PC-42171](https://passculture.atlassian.net/browse/PC-42171)

### Contexte
Le ticket [PC-40019](https://passculture.atlassian.net/browse/PC-40019) a ajouté sur pass-culture-main l'endpoint GET /native/v1/artists/{artist_id}/similar, qui expose une playlist d'artistes similaires sur la page artiste de l'app native.

Le repo pass-culture-recommendation-proxy expose déjà les endpoints `/similar_offers` et `/playlist` en miroir du backend principal. Pour éviter une désynchronisation entre les deux repos à mesure que le proxy sera déployé, il faut y ajouter l'équivalent pour les artistes similaires.

### Point d'attention pour les reviewers
Le proxy renvoie la réponse brute de la DS (similar_artists + artist_id_match + rank), pas le format enrichi du backend principal (artists avec id, name, image). À voir si on fera évoluer ce comportement plus tard ou non